### PR TITLE
Python 3 and Django 1.11 compatibility changes

### DIFF
--- a/inventar/urls.py
+++ b/inventar/urls.py
@@ -12,7 +12,7 @@
 # OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.conf import settings
 
@@ -26,7 +26,7 @@ from inventory.views import graph
 from inventory.views import stats
 from inventory.views import upload
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', home, name='home'),
     #(r'^openid/', include('django_openid_auth.urls')),
 
@@ -36,5 +36,5 @@ urlpatterns = patterns('',
     url(r'^stats/$', stats, name='stats'),
     url(r'^upload/$', upload, name='upload'),
 
-    url(r'^admin/', include(admin.site.urls)),
-) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+    url(r'^admin/', include(admin.site.urls))] + \
+    static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -16,8 +16,8 @@ from django.utils.translation import ugettext_lazy as _
 from django.contrib import admin
 from django.forms.widgets import Select
 from django.db.models import ForeignKey
-import filters
-import models
+from inventory import filters
+from inventory import models
 
 class BarcodeInline(admin.TabularInline):
 	model = models.Barcode

--- a/inventory/filters.py
+++ b/inventory/filters.py
@@ -14,7 +14,7 @@
 
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.admin import SimpleListFilter
-import models
+from inventory import models
 
 class HasParent(SimpleListFilter):
 	# Human-readable title which will be displayed in the

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -18,11 +18,11 @@ from django.shortcuts import render_to_response
 from django.shortcuts import render
 from django.http import HttpResponse
 from django.db.models import Q
-import models
+from inventory import models
 from django.core.mail import mail_admins
-from forms import UploadFileForm
+from inventory.forms import UploadFileForm
 from django.core.exceptions import ObjectDoesNotExist
-from models import Barcode
+from inventory.models import Barcode
 
 
 


### PR DESCRIPTION
Trying to set the inventory system up on a contemporary system runs into a few small issues. Fixed here.

Last patch may break compatibility with old versions of Django (pre 1.8 probably).