### PR TITLE
fix: Increase barcode search input maxlength from 4 to 6

### DIFF
--- a/inventar/templates/base.html
+++ b/inventar/templates/base.html
@@ -20,7 +20,7 @@
 					<li><br></li>
 					<li>{% trans "Search Item" %}:
 						<ul>
-					<li><form action="?" target="_self" id="itemchooser" onsubmit="location.assign('/item/'+document.forms['itemchooser']['id'].value+'/'); return false;"><input maxlength="4" name="id" type="text" title="{% trans "Get Item by ID" %}"/></form></li>
+					<li><form action="?" target="_self" id="itemchooser" onsubmit="location.assign('/item/'+document.forms['itemchooser']['id'].value+'/'); return false;"><input maxlength="6" name="id" type="text" title="{% trans "Get Item by ID" %}"/></form></li>
 					<li><form action="?" target="_self" id="itemsearch" onsubmit="location.assign('/search/'+document.forms['itemsearch']['term'].value+'/'); return false;"><input name="term" type="text" title="{% trans "Search Item by Name and Description" %}"/></form></li>
 						</ul>
 					</li>


### PR DESCRIPTION
Nils told me that there a 5 character codes already in use and that they cannot be entered in the web ui currently. 

When looking I found that the restriction seems to be only in the HTML template, did change this to 6 for now. The model seems to allow up to 10, the URL seems to allow up to 6.
